### PR TITLE
Do not mention blocked users

### DIFF
--- a/gitlab2sentry/utils/gitlab_provider.py
+++ b/gitlab2sentry/utils/gitlab_provider.py
@@ -221,7 +221,10 @@ class GitlabProvider:
             [
                 f"@{member.username}"
                 for member in project.members.all()
-                if member.access_level >= GITLAB_MENTIONS_ACCESS_LEVEL
+                if (
+                    member.access_level >= GITLAB_MENTIONS_ACCESS_LEVEL
+                    and member.state != "blocked"
+                )
             ]
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,34 @@ def sentry_provider_fixture():
     yield SentryProvider()
 
 
+class TestGitlabMember:
+    def __init__(self, username, access_level, state):
+        self.username = username
+        self.access_level = access_level
+        self.state = state
+
+
+TEST_GITLAB_PROJECT_MEMBERS = [
+    TestGitlabMember("active_user", 40, "active"),
+    TestGitlabMember("blocked_user", 40, "blocked")
+]
+
+
+class TestGitlabProject:
+    def __init__(self):
+        self.members = TestGitlabMemberManager()
+
+
+class TestGitlabMemberManager:
+    def all(self):
+        return TEST_GITLAB_PROJECT_MEMBERS
+
+
+@pytest.fixture
+def gitlab_project_fixture():
+    yield TestGitlabProject()
+
+
 def create_test_g2s_project(**kwargs):
     return G2SProject(
         1,

--- a/tests/test_gitlab_provider.py
+++ b/tests/test_gitlab_provider.py
@@ -86,6 +86,18 @@ def test_from_iso_to_datetime(gitlab_provider_fixture):
     )
 
 
+def test_get_default_mentions(gitlab_provider_fixture, gitlab_project_fixture):
+    _mentioned_members = (
+        gitlab_provider_fixture._get_default_mentions(gitlab_project_fixture).split(", ")
+    )
+    _project_non_blocked_members = [
+        member
+        for member in gitlab_project_fixture.members.all()
+        if member.state != "blocked"
+    ]
+    assert len(_mentioned_members) == len(_project_non_blocked_members)
+
+
 def test_get_project(gitlab_provider_fixture, mocker):
     mocker.patch.object(
         gitlab_provider_fixture._gql_client,


### PR DESCRIPTION
## What this PR do?

Upon `GitlabProvider._get_default_mentions` it adds an additional check for the fetched `member` of the `project` and if its `member.state == 'blocked` it doesn't include them in the members mention list.

Also, it adds a dedicated test case for this new feature.

## What Issues this PR fixes?

fixes #13 