### PR TITLE
fix: remove glq fetch schema flag

### DIFF
--- a/gitlab2sentry/utils/gitlab_provider.py
+++ b/gitlab2sentry/utils/gitlab_provider.py
@@ -22,7 +22,7 @@ class GraphQLClient:
     ):
         self._client = Client(
             transport=self._get_transport(url, token),
-            fetch_schema_from_transport=True,
+            fetch_schema_from_transport=False,
             execute_timeout=settings.gitlab_graphql_timeout,
         )
         websockets_logger.setLevel(logging.WARNING)


### PR DESCRIPTION
fetch_schema_from_transport was unnecessary setup to true
since 18.8.4 it caused error to get users with gql