### PR TITLE
fix: env variable import

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,13 +1,12 @@
 import sentry_sdk
 
 from gitlab2sentry import Gitlab2Sentry
-from gitlab2sentry.resources import SENTRY_DSN, SENTRY_ENV
-
+from gitlab2sentry.resources import settings
 if __name__ == "__main__":
     sentry_sdk.init(  # type: ignore
         debug=False,
-        dsn=SENTRY_DSN,
-        environment=SENTRY_ENV,
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_env,
     )
     runner = Gitlab2Sentry()
     runner.update()


### PR DESCRIPTION
Since changes to pydantic, variables weren't import well in the run.py file